### PR TITLE
g4-common: audio: add Dynamics Processing effect

### DIFF
--- a/audio/audio_effects.xml
+++ b/audio/audio_effects.xml
@@ -9,6 +9,7 @@
         <library name="visualizer_sw" path="libvisualizer.so"/>
         <library name="visualizer_hw" path="libqcomvisualizer.so"/>
         <library name="downmix" path="libdownmix.so"/>
+        <library name="dynamics_processing" path="libdynproc.so"/>
         <library name="loudness_enhancer" path="libldnhncr.so"/>
         <library name="proxy" path="libeffectproxy.so"/>
         <library name="offload_bundle" path="libqcompostprocbundle.so"/>
@@ -52,6 +53,7 @@
         </effectProxy>
         <effect name="downmix" library="downmix" uuid="93f04452-e4fe-41cc-91f9-e475b6d1d69f"/>
         <effect name="loudness_enhancer" library="loudness_enhancer" uuid="fa415329-2034-4bea-b5dc-5b381c8d1e2c"/>
+        <effect name="dynamics_processing" library="dynamics_processing" uuid="e0e6539b-1781-7261-676f-6d7573696340"/>
         <!-- working: qcom overlay -->
         <!--
         <effect name="aec" library="qcom_pre_processing" uuid="d2f1b180-4a8c-11e5-9883-0002a5d5c51b"/>


### PR DESCRIPTION
In Android 9 Pie is a new "Dynamics Processing" audio effect. The code is already built and included within the distribution. This commit enables the audio effect in the config file.

This change is needed for any device that upgraded from Android 8 Oreo (or prior) to Android 9 Pie. For example, here's Google's commit for marlin (Pixel XL) when they upgraded: https://github.com/LineageOS/android_device_google_marlin/commit/3a44f94401dc3e87732f900046cc97cd0ddee9c3

You can test by running [Wavelet](https://play.google.com/store/apps/details?id=com.pittvandewitt.wavelet) on the device. Without this commit it will give an error "Wavelet was unable to instantiate DynamicsProcessing effects". With it, no error and it works. (Actually I made this PR only because I wanted Wavelet to run on my device!)